### PR TITLE
Feature/remove resource type from resources

### DIFF
--- a/api/routes/resources.js
+++ b/api/routes/resources.js
@@ -7,10 +7,6 @@ module.exports = router;
 router.get('/', async function (req, res) {
   try {
     const resources = await mainModel.resources.getAll();
-    for (const resource of resources) {
-      const resourceType = await mainModel.resourceTypes.getById(resource.resourceTypeId);
-      resource.resourceTypeName = resourceType.name;
-    }
     res.json(resources);
   } catch (error) {
     console.log(`Error trying to GET resource: ${error}`);
@@ -29,8 +25,6 @@ router.get('/:id', async function (req, res) {
     if (resource == null) {
       res.status(404).send('No such resource');
     } else {
-      const resourceType = await mainModel.resourceTypes.getById(resource.resourceTypeId);
-      resource.resourceTypeName = resourceType.name;
       res.json(resource);
     }
   } catch (error) {
@@ -65,7 +59,6 @@ router.put('/:id', async function (req, res) {
     res.status(400).send('Resource id parameter and id in request body must match.');
     return;
   }
-  delete resourceItem.resourceTypeName;
   resourceItem.id = id;
   if (!checkPutItemFields(resourceItem, mainModel.resources)) {
     res.status(400).send('Resource does not have required fields.');

--- a/website/routes/select-a-resource.js
+++ b/website/routes/select-a-resource.js
@@ -5,23 +5,37 @@ const settings = require('../settings');
 
 const apiUrl = settings.apiUrl;
 
-const router = express.Router()
+const router = express.Router();
 module.exports = router;
 
-router.get('/select-a-resource', function (req, res) {
-
-    const url = `${apiUrl}/resources`;
-
-    axios.get(url)
-        .then(function (response) {
-            res.render('select-a-resource.html', {
-                resources: response.data
-            });
-        })
-        .catch(function (error) {
-            console.log(error);
-            res.render('error.html', {
-                safeErrorMessage: utilities.safeErrorMessage(error.message)
-            });
-        });
+router.get('/select-a-resource', async function (req, res) {
+  try {
+    const resources = await axios.get(`${apiUrl}/resources`);
+    const resourceTypes = await axios.get(`${apiUrl}/resource-types`);
+    for (const r of resources.data) {
+      r.resourceTypeName = _getResourceTypeName(resourceTypes.data, r.resourceTypeId);
+    }
+    res.render('select-a-resource.html', { resources: resources.data });
+  } catch (error) {
+    console.log(error);
+    res.render('error.html', {
+      safeErrorMessage: utilities.safeErrorMessage(error.message)
+    });
+  }
 });
+
+/**
+ * Gets the name of a resource type, given its id.
+ *
+ * @param {*} resourceTypes - An array of all resourceTypes.
+ * @param {*} typeId - The resourceType id.
+ * @returns {string|null} - Returns the name of the resourceType or null if not found.
+ */
+function _getResourceTypeName (resourceTypes, typeId) {
+  for (const r of resourceTypes) {
+    if (r.id === typeId) {
+      return r.name;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
The resources table only includes the resource_type_id column, not the name of the resource type.

The front end needs the resource type name as well, when displaying resources.

Previously the resources API endpoint (/api/resources) included the resourceTypeName property in the returned items.

To keep the resource endpoint consistent with others -- and only supplying what its underlying table provides -- the resourceTypeName property has been removed from the resources endpoint.

Now, the route for the select-a-resource page on the website gets this information from a separate call to the resource-types endpoint.